### PR TITLE
use SPI_FLASH_SEC_SIZE instead of FLASH_SECTOR_SIZE

### DIFF
--- a/arm_debug.cpp
+++ b/arm_debug.cpp
@@ -729,6 +729,7 @@ uint32_t ARMDebug::wireRead(unsigned nBits)
         digitalWrite(clockPin, LOW);
         mask <<= 1;
         digitalWrite(clockPin, HIGH);
+        delayMicroseconds(1); //added this because the transfere gets so much more reliable on ESP32 and without it you have to build retry mehcanisms around every single step
     }
 
     log(LOG_TRACE_SWD, "SWD Read  %08x (%d)", result, nBits);

--- a/arm_kinetis_reg.h
+++ b/arm_kinetis_reg.h
@@ -35,10 +35,6 @@
 #pragma once
 #include "arm_reg.h"
 
-#ifndef FLASH_SECTOR_SIZE
-  #definde FLASH_SECTOR_SIZE 0x1000 //this makesthe whole project dependant on https://github.com/esp8266/Arduino. I want to use the Classes on an ESP32 so Im putting this here
-#endif
-
 // chapter 11: Port control and interrupts (PORT)
 #define REG_PORTA_PCR0              0x40049000            // Pin Control Register n
 #define REG_PORT_PCR_ISF            0x01000000            // Interrupt Status Flag

--- a/arm_kinetis_reg.h
+++ b/arm_kinetis_reg.h
@@ -35,6 +35,10 @@
 #pragma once
 #include "arm_reg.h"
 
+#ifndef FLASH_SECTOR_SIZE
+  #definde FLASH_SECTOR_SIZE 0x1000 //this makesthe whole project dependant on https://github.com/esp8266/Arduino. I want to use the Classes on an ESP32 so Im putting this here
+#endif
+
 // chapter 11: Port control and interrupts (PORT)
 #define REG_PORTA_PCR0              0x40049000            // Pin Control Register n
 #define REG_PORT_PCR_ISF            0x01000000            // Interrupt Status Flag


### PR DESCRIPTION
Im using the ARMDebug class in my ESP32 project and I wanted to include your repository as a library instead of copying the classes to mine.
Unfortunately the ARMKinetisDebug class can not be compiled in a ESP32 environment because FLASH_SECTOR_SIZE is undefined.
spi_flash_geometry.h defines them as equal on ESP8266 but in the ESP32 SDK only SPI_FLASH_SEC_SIZE exists.
 